### PR TITLE
Update docker-compose.yml: Fix ppr typo

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       WAREHOUSE_PASSWORD: ${POSTGRES_PASSWORD}
       WAREHOUSE_DB: ${POSTGRES_DB}
       WAREHOUSE_HOST: ${POSTGRES_HOST}
-      WARREHOUSE_PORT: ${POSTGRES_PORT}
+      WAREHOUSE_PORT: ${POSTGRES_PORT}
 
   dashboard:
     image: metabase/metabase


### PR DESCRIPTION
Found a typo in the docker-compose yaml file for the pipelinerunner container:

      -WARREHOUSE_PORT: ${POSTGRES_PORT}
      +WAREHOUSE_PORT: ${POSTGRES_PORT}

The implications of this remains to be seen. I have since located the same typo across other projects. See here, for example:
https://github.com/josephmachado/local_dev/blob/aa167edc411fd5e61f97374515dfa95b1b7c8b03/docker-compose.yml#L35